### PR TITLE
Relax outdated upper bounds (base-compat*, bytestring)

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20210529
+# version: 0.13.20210901
 #
-# REGENDATA ("0.13.20210529",["github","cabal.project"])
+# REGENDATA ("0.13.20210901",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -35,9 +35,9 @@ jobs:
             compilerVersion: "8.4"
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-9.2.0.20210422
+          - compiler: ghc-9.2.0.20210821
             compilerKind: ghc
-            compilerVersion: 9.2.0.20210422
+            compilerVersion: 9.2.0.20210821
             setup-method: ghcup
             allow-failure: true
           - compiler: ghc-9.0.1
@@ -126,7 +126,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.14.1/x86_64-linux-ghcup-0.1.14.1 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.16.2/x86_64-linux-ghcup-0.1.16.2 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.4.0.0
@@ -336,4 +336,5 @@ jobs:
           rm -f cabal.project.local
       - name: constraint set time-1.10
         run: |
+          if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='time ^>=1.10' --dependencies-only -j2 all ; fi
           if [ $((GHCJSARITH || ! GHCJSARITH && HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='time ^>=1.10' all ; fi

--- a/splitmix.cabal
+++ b/splitmix.cabal
@@ -46,7 +46,7 @@ tested-with:
      || ==8.8.4
      || ==8.10.4
      || ==9.0.1
-     || ==9.2.0.20210422
+     || ==9.2.0.20210821
   , GHCJS ==8.4
 
 extra-source-files:
@@ -169,7 +169,7 @@ test-suite splitmix-tests
 
   build-depends:
       base
-    , base-compat           >=0.11.1  && <0.12
+    , base-compat           >=0.11.1  && <0.13
     , containers            >=0.4.0.0 && <0.7
     , HUnit                 ==1.3.1.2 || >=1.6.0.0 && <1.7
     , math-functions        ==0.1.7.0 || >=0.3.3.0 && <0.4
@@ -206,8 +206,8 @@ test-suite splitmix-dieharder
   build-depends:
       async                  >=2.2.1    && <2.3
     , base
-    , base-compat-batteries  >=0.10.5   && <0.12
-    , bytestring             >=0.9.1.8  && <0.11
+    , base-compat-batteries  >=0.10.5   && <0.13
+    , bytestring             >=0.9.1.8  && <0.12
     , deepseq
     , process                >=1.0.1.5  && <1.7
     , random


### PR DESCRIPTION
Relax outdated upper bounds (base-compat*, bytestring).

This allows building with GHC 9.2-rc1 as follows:

    $ cabal build all -w ghc-9.2.0 --allow-newer=async:base
    $ cabal test -w ghc-9.2.0 --allow-newer=async:base

The benchmarks do not build yet with GHC 9.2; but I suppose making the
supplied revisions will help moving the ecosystem forward towards 9.2.