### PR TITLE
Support GHC 9.4

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,8 @@
 packages: .
 
 tests: True
+
+source-repository-package
+    type: git
+    location: https://github.com/parsonsmatt/primitive
+    tag: 99ebd4b81ab320b71dcffd0c20082c5b2ccbcfee

--- a/splitmix.cabal
+++ b/splitmix.cabal
@@ -77,7 +77,7 @@ library
   -- ghc-options: -fplugin=DumpCore -fplugin-opt DumpCore:core-html
 
   build-depends:
-      base     >=4.3     && <4.17
+      base     >=4.3     && <4.18
     , deepseq  >=1.3.0.0 && <1.5
 
   if flag(optimised-mixer)


### PR DESCRIPTION
Depends on https://github.com/haskell/primitive/pull/340

Tests run locally and pass with `cabal test --allow-newer`. 

Without `--allow-newer`, we get a problem with `vector`'s upper bound.