### PR TITLE
Add WASI initialization support

### DIFF
--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -44,3 +44,29 @@ jobs:
 
       - name: Test
         run: cabal test all --enable-tests --test-show-details=direct
+  wasi:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ghc: ['9.6', '9.8', '9.10', '9.12']
+      fail-fast: false
+    steps:
+    - name: setup-ghc-wasm32-wasi
+      run: |
+        cd $(mktemp -d)
+        curl -L https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta/-/archive/$GHC_WASM_META_REV/ghc-wasm-meta.tar.gz | tar xz --strip-components=1
+        ./setup.sh
+        ~/.ghc-wasm/add_to_github_path.sh
+      env:
+        GHC_WASM_META_REV: f0faac335c6f5e967d1bdbfca5768232483fd2a8
+        FLAVOUR: ${{ matrix.ghc }}
+    - uses: actions/checkout@v4
+    - name: Build
+      run: |
+        wasm32-wasi-cabal build splitmix splitmix:test:examples splitmix:test:initialization
+    - name: Test
+      run: |
+        for test in examples initialization; do
+          echo --- Running test $test ---
+          wasmtime $(wasm32-wasi-cabal list-bin splitmix:test:$test)
+        done

--- a/cbits-wasi/init.c
+++ b/cbits-wasi/init.c
@@ -1,0 +1,8 @@
+#include <stdint.h>
+#include <sys/random.h>
+
+uint64_t splitmix_init() {
+  uint64_t result;
+  int r = getentropy(&result, sizeof(uint64_t));
+  return r == 0 ? result : 0xfeed1000;
+}

--- a/splitmix.cabal
+++ b/splitmix.cabal
@@ -93,7 +93,11 @@ library
         c-sources: cbits-win/init.c
 
       else
-        c-sources: cbits-unix/init.c
+        if arch(wasm32)
+          c-sources: cbits-wasi/init.c
+
+        else
+          c-sources: cbits-unix/init.c
 
     else
       cpp-options:   -DSPLITMIX_INIT_COMPAT=1
@@ -226,7 +230,9 @@ test-suite splitmix-testu01
 test-suite initialization
   default-language: Haskell2010
   type:             exitcode-stdio-1.0
-  ghc-options:      -Wall -threaded -rtsopts
+  ghc-options:      -Wall -rtsopts
+  if !arch(wasm32)
+    ghc-options:    -threaded
   hs-source-dirs:   tests
   main-is:          Initialization.hs
   build-depends:


### PR DESCRIPTION
The current unix logic does not work for the new GHC WASM backend for two reasons:

 - The filesystem is not necessarily mounted in such a way that `/dev/urandom` exists (e.g. it is only given access to a confined directory, or the host systen is non-unix, or it is run in a browser context etc.)
 - The code fails to link due to the initialization fallback using functions (`clock`, `getpid`) not being available.

The current WASI snapshot (as well as future planned versions) do specify an entropy source, [`random_get`](https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#-random_getbuf-pointeru8-buf_len-size---result-errno) which is used to back e.g. [`getentropy`](https://man7.org/linux/man-pages/man3/getentropy.3.html).

In this PR, I added `cbits` for WASI calling `getentropy`, but alternative approaches (i.e. merging this into the existing unix logic and e.g. disabling the fallback on WASI; or simply using `getentropy` directly in the unix logic) are also feasible, happy to change.

I only run two test suites on CI (the `initialization` one should be most relevant here) as e.g. the `splitmix-tests` suite does not yet build.