### PR TITLE
Update GHCJS conditions to also support the GHC JavaScript backend

### DIFF
--- a/splitmix.cabal
+++ b/splitmix.cabal
@@ -90,7 +90,7 @@ library
   -- because it's valuable that splitmix and QuickCheck doesn't
   -- depend on about anything
 
-  if impl(ghcjs)
+  if impl(ghcjs) || arch(javascript)
     cpp-options: -DSPLITMIX_INIT_GHCJS=1
 
   else

--- a/src/System/Random/SplitMix/Init.hs
+++ b/src/System/Random/SplitMix/Init.hs
@@ -6,7 +6,7 @@ module System.Random.SplitMix.Init (
 
 import Data.Word (Word64)
 
-#if defined(SPLITMIX_INIT_GHCJS) && __GHCJS__
+#if defined(SPLITMIX_INIT_GHCJS) && (__GHCJS__ || defined(javascript_HOST_ARCH))
 
 import Data.Word (Word32)
 
@@ -26,12 +26,17 @@ import System.CPUTime (cpuTimePrecision, getCPUTime)
 
 initialSeed :: IO Word64
 
-#if defined(SPLITMIX_INIT_GHCJS) && __GHCJS__
+#if defined(SPLITMIX_INIT_GHCJS) && (__GHCJS__ || defined(javascript_HOST_ARCH))
 
 initialSeed = fmap fromIntegral initialSeedJS
 
 foreign import javascript
+#if __GHCJS__
     "$r = Math.floor(Math.random()*0x100000000);"
+#else
+    -- defined(javascript_HOST_ARCH)
+    "(() => { return Math.floor(Math.random()*0x100000000); })"
+#endif
     initialSeedJS :: IO Word32
 
 #else
@@ -56,3 +61,4 @@ initialSeed =  do
 
 #endif
 #endif
+


### PR DESCRIPTION
This MR is to update CPP and cabal file conditions to support the GHC JavaScript backend.

Because the JavaScript backend uses a different FFI syntax than GHCJS, the `initialSeedJS` function now has two versions of the import string.

The main motivation for this change is the use of this function in `ghcjs-base`'s testsuite.