### PR TITLE
Build with ghc(js) 9.10

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,6 +2,5 @@ packages: .
 
 tests: True
 
-allow-newer: async-2.2.5:base
-allow-newer: hashable-1.4.4.0:base
-allow-newer: hashable-1.4.4.0:containers
+if arch(javascript)
+  extra-packages: ghci

--- a/splitmix.cabal
+++ b/splitmix.cabal
@@ -81,7 +81,7 @@ library
   -- because it's valuable that splitmix and QuickCheck doesn't
   -- depend on about anything
 
-  if impl(ghcjs)
+  if impl(ghcjs) || arch(javascript)
     cpp-options: -DSPLITMIX_INIT_GHCJS=1
 
   else

--- a/splitmix.cabal
+++ b/splitmix.cabal
@@ -115,6 +115,8 @@ benchmark comparison
     , random
     , splitmix
     , tf-random   >=0.5     && <0.6
+  if arch(javascript)
+    buildable: False
 
 benchmark simple-sum
   type:             exitcode-stdio-1.0
@@ -221,6 +223,8 @@ test-suite splitmix-testu01
       base
     , base-compat-batteries  >=0.10.5 && <0.14
     , splitmix
+  if arch(javascript)
+    buildable: False
 
 test-suite initialization
   default-language: Haskell2010

--- a/src/System/Random/SplitMix/Init.hs
+++ b/src/System/Random/SplitMix/Init.hs
@@ -6,7 +6,7 @@ module System.Random.SplitMix.Init (
 
 import Data.Word (Word64)
 
-#if defined(SPLITMIX_INIT_GHCJS) && __GHCJS__
+#if defined(SPLITMIX_INIT_GHCJS) && (__GHCJS__ || defined(javascript_HOST_ARCH))
 
 import Data.Word (Word32)
 
@@ -26,12 +26,17 @@ import System.CPUTime (cpuTimePrecision, getCPUTime)
 
 initialSeed :: IO Word64
 
-#if defined(SPLITMIX_INIT_GHCJS) && __GHCJS__
+#if defined(SPLITMIX_INIT_GHCJS) && (__GHCJS__ || defined(javascript_HOST_ARCH))
 
 initialSeed = fmap fromIntegral initialSeedJS
 
 foreign import javascript
+#if __GHCJS__
     "$r = Math.floor(Math.random()*0x100000000);"
+#else
+    -- defined(javascript_HOST_ARCH)
+    "(() => { return Math.floor(Math.random()*0x100000000); })"
+#endif
     initialSeedJS :: IO Word32
 
 #else
@@ -56,3 +61,4 @@ initialSeed =  do
 
 #endif
 #endif
+


### PR DESCRIPTION
Built using `haskell.nix`:
_____
`default.nix`:
```
let deps = {
      "haskell.nix" = builtins.fetchTarball {
        url = "https://github.com/input-output-hk/haskell.nix/archive/d8c50dcaf3d3d589829ee9be9d5dba8279b8cc59.tar.gz";
        sha256 = "0a5hgryz6nszmy67yf1aks399h2aw0nj845518c4prs5c6ns1z7p";
      };
    };

    haskellNix = import deps."haskell.nix" {};

    # Import nixpkgs and pass the haskell.nix provided nixpkgsArgs
    pkgs = import
      # haskell.nix provides access to the nixpkgs pins which are used by our CI,
      # hence you will be more likely to get cache hits when using these.
      # But you can also just use your own, e.g. '<nixpkgs>'.
      haskellNix.sources.nixpkgs-unstable
      # These arguments passed to nixpkgs, include some patches and also
      # the haskell.nix functionality itself as an overlay.
      haskellNix.nixpkgsArgs;

    project = pkgs: pkgs.haskell-nix.project {
      src = ./.;

      shell.withHaddock = if pkgs.stdenv.hostPlatform.isGhcjs then false else true;

      # Specify the GHC version to use.
      compiler-nix-name = "ghc910"; # Not required for `stack.yaml` based projects.
    };

in {
  ghc = project pkgs;
  ghc-js = project pkgs.pkgsCross.ghcjs;
}
```
_____
`shell.nix`:
```
let projects = import ./default.nix;
    project = projects.ghc;
in project.shellFor {
  tools = {
    cabal = "latest";
  };

  buildInputs = with project.pkgs; [
    nodejs-slim_latest
  ];

  # Sellect cross compilers to include.
  crossPlatforms = ps: with ps; [
    ghcjs # Adds support for `javascript-unknown-ghcjs-cabal build` in the shell
  ];
}
```