### PR TITLE
Fix building on Android

### DIFF
--- a/cbits-unix/init.c
+++ b/cbits-unix/init.c
@@ -1,8 +1,8 @@
 #include <stdint.h>
 #include <unistd.h>
 
-/* for macos */
-#ifdef __APPLE__
+/* for macos and android */
+#if defined(__APPLE__) || defined(__BIONIC__)
 #include <sys/random.h>
 #endif
 


### PR DESCRIPTION
Version 0.1.2 broke building on for Android:

```
cbits-unix/init.c:11:10: error:
     error: call to undeclared function 'getentropy'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
            int r = getentropy(&result, sizeof(uint64_t));
```