### PR TITLE
Don't include sys/random.h

### DIFF
--- a/cbits-unix/init.c
+++ b/cbits-unix/init.c
@@ -1,6 +1,5 @@
 #include <stdint.h>
 #include <unistd.h>
-#include <sys/random.h>
 
 uint64_t splitmix_init() {
 	uint64_t result;


### PR DESCRIPTION
As far as I can trace, Android doesn't need it:
https://android.googlesource.com/platform/bionic/+/7110157e941f0895638c81872b535d8781cf79cf

OpenBSD doesnt have that header. So lets not include it.

Resolves #101