### PR TITLE
Add support for versions of glibc older than 2.25

### DIFF
--- a/cbits-unix/init.c
+++ b/cbits-unix/init.c
@@ -1,9 +1,58 @@
+// This is needed to ensure that "getentropy" is available when glibc is used.
+#define _DEFAULT_SOURCE
+
 #include <stdint.h>
+
+#if defined(__GLIBC__) && (__GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 25))
+// "getentropy" was added in glibc 2.25, so a fallback implementation is used
+// for older versions.
+
+#include <stdio.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <time.h>
 #include <unistd.h>
-#include <sys/random.h>
+
+uint64_t splitmix_init() {
+    /* if there is /dev/urandom, read from it */
+    FILE *urandom = fopen("/dev/urandom", "r");
+    if (urandom) {
+        uint64_t result = 0;
+        size_t r = fread(&result, sizeof(uint64_t), 1, urandom);
+        fclose(urandom);
+
+        if (r == 1) {
+            return result;
+        } else {
+            return 0xfeed1000;
+        }
+
+    } else {
+        /* time of day */
+        struct timeval tp = {0, 0};
+        gettimeofday(&tp, NULL);
+
+        /* cputime */
+        clock_t c = clock();
+
+        /* process id */
+        pid_t p = getpid();
+
+        return ((uint64_t) tp.tv_sec)
+            ^ ((uint64_t) tp.tv_usec)
+            ^ ((uint64_t) c << 16)
+            ^ ((uint64_t) p << 32);
+    }
+}
+
+#else
+
+#include <unistd.h>
 
 uint64_t splitmix_init() {
 	uint64_t result;
 	int r = getentropy(&result, sizeof(uint64_t));
 	return r == 0 ? result : 0xfeed1000;
 }
+
+#endif


### PR DESCRIPTION
The "getentropy" function was added in glibc version 2.25.

See: https://man7.org/linux/man-pages/man3/getentropy.3.html

This PR adds a fallback implementation of "splitmix_init" that will be used on older versions of glibc.

The fallback implementation is the implementation that was previously used in this library.

See: https://github.com/haskellari/splitmix/commit/2ef916ac3e6c7bc8c014cc2e0b9b481504f9b803

glibc 2.25 was released in 2017 (See: https://sourceware.org/glibc/wiki/Glibc%20Timeline) and found its way to Linux distros during the next few years.

There are many active Linux LTS productions systems that are still running older versions of glibc. If we want to run our programs on them, then the programs must be compiled with a version of glibc that is equal-to or older than what they have.

Suggested CHANGELOG entry:

- Add support for versions of glibc older than 2.25