### PR TITLE
Add a workaround for usage on Android

### DIFF
--- a/cbits-unix/init.c
+++ b/cbits-unix/init.c
@@ -8,6 +8,10 @@
 
 uint64_t splitmix_init() {
 	uint64_t result;
+#if (!defined(__ANDROID__) || __ANDROID_API__ >= 28)
 	int r = getentropy(&result, sizeof(uint64_t));
+#else
+	int r = -1;
+#endif
 	return r == 0 ? result : 0xfeed1000;
 }

--- a/cbits-unix/init.c
+++ b/cbits-unix/init.c
@@ -6,6 +6,8 @@
 #include <sys/random.h>
 #endif
 
+#include <crypt.h>
+
 uint64_t splitmix_init() {
 	uint64_t result;
 	int r = getentropy(&result, sizeof(uint64_t));

--- a/cbits-unix/init.c
+++ b/cbits-unix/init.c
@@ -6,8 +6,6 @@
 #include <sys/random.h>
 #endif
 
-#include <crypt.h>
-
 uint64_t splitmix_init() {
 	uint64_t result;
 	int r = getentropy(&result, sizeof(uint64_t));


### PR DESCRIPTION
Greetings,

`getentropy` doesn't exist on Android, so when building on Android, we need to have a workaround: https://github.com/termux/termux-packages/pull/25265