### PR TITLE
Add cross-platform testing utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ cabal.project.local
 bench.html
 splitmix-hugs
 hugs.output
+
+# nix
+result
+result-*

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,20 @@ generate-mix32 :
 doctest :
 	perl -i -e 'while (<ARGV>) { print unless /package-id base-compat-\d+(\.\d+)*/; }' .ghc.environment.*
 	doctest src
+
+native:
+	nix-build -A native.splitmix
+
+freebsd:
+	nix-build -A freebsd.splitmix
+
+android:
+	nix-build -A android.splitmix
+
+js:
+	nix-build -A js.splitmix
+
+wasm:
+	nix shell \
+	  'gitlab:haskell-wasm/ghc-wasm-meta/7927129e42bcd6a54b9e06e26455803fa4878261?host=gitlab.haskell.org' \
+	  --command sh -c "wasm32-wasi-cabal update && wasm32-wasi-cabal test all --ghc-options='-single-threaded' --test-wrapper=wasmtime"

--- a/cabal.project
+++ b/cabal.project
@@ -5,3 +5,10 @@ tests: True
 allow-newer: async-2.2.5:base
 allow-newer: hashable-1.4.4.0:base
 allow-newer: hashable-1.4.4.0:containers
+
+-- Due to error when building 'splitmix-tests': undefined symbol: gethostname
+if arch(wasm32)
+  source-repository-package
+    type: git
+    location: https://github.com/haskell-wasm/hostname
+    tag: 8d110f03b3117af233683ac90b125fcfc767a2ef

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,43 @@
+let
+  pins = {
+    # merge ancestor of https://github.com/NixOS/nixpkgs/pull/413046
+    nixpkgs = builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/3ea4dc04503b4370e06eca0e43c062c8b11883fa.tar.gz";
+      sha256 = "sha256:04ygvidh3l3ls755b2wgl148567n9rnj168s87j03agly5wrf19c";
+    };
+  };
+
+  defaultNixpkgs = import pins.nixpkgs {};
+
+  cachedPackageSetVersion = "ghc" + builtins.replaceStrings ["."] [""] defaultNixpkgs.haskellPackages.ghc.version;
+
+  mkNixpkgs = version: import pins.nixpkgs {
+    config = {
+      packageOverrides = nixpkgs: with nixpkgs.haskell.lib.compose; {
+        haskell = nixpkgs.haskell // {
+          packages = nixpkgs.haskell.packages // {
+            "${version}" = nixpkgs.haskell.packages.${version}.override(old: {
+              overrides = self: super: {
+                # callCabal2nix is broken because of testu01 being missing so re-use splitmix drv
+                splitmix = overrideSrc
+                  { src = nixpkgs.lib.sourceFilesBySuffices ./. [ ".hs" ".cabal" ".c" ".md" "LICENSE" ]; }
+                  super.splitmix;
+              };
+            });
+          };
+        };
+      };
+    };
+  };
+
+  build = version: getPkgs: ((getPkgs (mkNixpkgs version)).haskell.packages.${version});
+
+  in {
+      native = build cachedPackageSetVersion (ps: ps);
+
+      freebsd = build cachedPackageSetVersion (ps: ps.pkgsCross.x86_64-freebsd);
+
+      android = build "ghc910" (ps: ps.pkgsCross.aarch64-android-prebuilt.pkgsStatic);
+
+      js = build "ghc912" (ps: ps.pkgsCross.ghcjs);
+    }


### PR DESCRIPTION
cc @amesgen @bodigrim @dmjio @maralorn @terrorjack @ymeister

## Problem

There've been several issues/PRs to splitmix attempting fixes for a platform that are generally hard to test on the maintainer side, and sometimes also end up breaking another platform in the process.

It seems to me there are two main sources of burden to maintainers when it comes to cross-platform support:
1) detecting failures
2) fixing failures

One suggested approach was to have a fork per platform, but if we want to minimize the aggregated ecosystem effort, it's better to handle things in one place, instead of having multiple downstreams project re-discover the forks and add them as patches for each platform they need.

## Solution
With this PR I add a few helpers using the nixpkgs cross infrastructure to target several platforms (when compatible with the build platform). 
If desired, these can be added to CI (potentially blocking merges and/or releases).

This would simplify the 'detecting' bit at the cost of a new bit of burden on maintaining the .nix. 
I can commit to that maintenance and I believe several others would agree to commit as well since that sort of work has been happening already, just scattered across repos. There's certainly been override/patch/source-repository-package juggling happening on nixpkgs/miso/reflex-dom/etc for a while, and this approach already seems like less work to me.

As for 'fixing', it should becomes less of a concern if we break things less.

So far I've only described building, and nothing about detecting/fixing runtime failures, which is the case for https://github.com/haskellari/splitmix/pull/75.
Currently, this PR only runs wasm tests, but the idea is to gradually expand coverage.

### Usage

```
$ uname -o -m
x86_64 GNU/Linux

$ make native 
nix-build -A native.splitmix
/nix/store/scnx4r5zddkwif3kz8vv5ni0in5xlpcw-splitmix-0.1.1

$ make freebsd
nix-build -A freebsd.splitmix
/nix/store/3rg9mp6qfbbvhgxvbir8388hxdn4rgfh-splitmix-x86_64-unknown-freebsd-0.1.1

$ make android
nix-build -A android.splitmix
/nix/store/a3v5j3lkx4viha00yr5sv8idgziwdshp-splitmix-static-aarch64-unknown-linux-musl-0.1.1

$ make js
nix-build -A js.splitmix
/nix/store/k8pfz2s8gbrqs1g7wv8na3qyqkj2gw3s-splitmix-0.1.1

$ make wasm
nix shell \
  'gitlab:haskell-wasm/ghc-wasm-meta/7927129e42bcd6a54b9e06e26455803fa4878261?host=gitlab.haskell.org' \
  --command sh -c "wasm32-wasi-cabal update && wasm32-wasi-cabal test all --ghc-options='-single-threaded' --test-wrapper=wasmtime"
(...)
Test suite examples: PASS
Test suite initialization: PASS
Test suite splitmix-dieharder: PASS
Test suite splitmix-th-test: PASS
Test suite splitmix-tests: PASS
Test suite montecarlo-pi-32: PASS
Test suite montecarlo-pi: PASS

