### PR TITLE
OpenBSD "Fix"

### DIFF
--- a/cbits-unix/init.c
+++ b/cbits-unix/init.c
@@ -1,6 +1,8 @@
 #include <stdint.h>
 #include <unistd.h>
+#ifndef __OpenBSD__ // OpenBSD does not use sys/random.h.
 #include <sys/random.h>
+#endif
 
 uint64_t splitmix_init() {
 	uint64_t result;


### PR DESCRIPTION
# la .lojban.
ni'o zengau pe'a fi le ka ce'u mapti la'oi .OpenBSD. noi ke'a na se pagbu la'o zoi. sys/random.h .zoi.

# English
The thing is "increased" in supporting OpenBSD.  `sys/random.h` is not a part of OpenBSD.

# .

```
vvx@kitt:~/prgs/splitmix$ cabal build
Configuration is affected by the following files:
- cabal.project
Build profile: -w ghc-9.8.3 -O1
In order, the following will be built (use -v for more details):
 - splitmix-0.1.3.1 (lib) (first run)
 - splitmix-0.1.3.1 (test:splitmix-th-test) (first run)
 - splitmix-0.1.3.1 (test:splitmix-tests) (first run)
 - splitmix-0.1.3.1 (test:splitmix-dieharder) (first run)
 - splitmix-0.1.3.1 (test:montecarlo-pi-32) (first run)
 - splitmix-0.1.3.1 (test:montecarlo-pi) (first run)
 - splitmix-0.1.3.1 (test:initialization) (first run)
 - splitmix-0.1.3.1 (test:examples) (first run)
Configuring library for splitmix-0.1.3.1...
Preprocessing library for splitmix-0.1.3.1...
Building library for splitmix-0.1.3.1...
[1 of 4] Compiling Data.Bits.Compat ( src-compat/Data/Bits/Compat.hs, dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/build/Data/Bits/Compat.o, dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/build/Data/Bits/Compat.dyn_o )
[2 of 4] Compiling System.Random.SplitMix.Init ( src/System/Random/SplitMix/Init.hs, dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/build/System/Random/SplitMix/Init.o, dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/build/System/Random/SplitMix/Init.dyn_o )
[3 of 4] Compiling System.Random.SplitMix ( src/System/Random/SplitMix.hs, dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/build/System/Random/SplitMix.o, dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/build/System/Random/SplitMix.dyn_o )
[4 of 4] Compiling System.Random.SplitMix32 ( src/System/Random/SplitMix32.hs, dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/build/System/Random/SplitMix32.o, dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/build/System/Random/SplitMix32.dyn_o )

cbits-unix/init.c:3:10: error:
     fatal error: 'sys/random.h' file not found
  |
3 | #include <sys/random.h>
  |          ^
#include <sys/random.h>
         ^~~~~~~~~~~~~~
1 error generated.
`clang' failed in phase `C Compiler'. (Exit code: 1)
Error: [Cabal-7125]
Failed to build splitmix-0.1.3.1 (which is required by test:splitmix-th-test from splitmix-0.1.3.1, test:splitmix-tests from splitmix-0.1.3.1 and others).

vvx@kitt:~/prgs/splitmix$ sed -i -e 's/^#include <sys\/ran/\/\//' cbits-unix/init.c
vvx@kitt:~/prgs/splitmix$ cabal build
Configuration is affected by the following files:
- cabal.project
Build profile: -w ghc-9.8.3 -O1
In order, the following will be built (use -v for more details):
 - splitmix-0.1.3.1 (lib) (first run)
 - splitmix-0.1.3.1 (test:splitmix-th-test) (first run)
 - splitmix-0.1.3.1 (test:splitmix-tests) (first run)
 - splitmix-0.1.3.1 (test:splitmix-dieharder) (first run)
 - splitmix-0.1.3.1 (test:montecarlo-pi-32) (first run)
 - splitmix-0.1.3.1 (test:montecarlo-pi) (first run)
 - splitmix-0.1.3.1 (test:initialization) (first run)
 - splitmix-0.1.3.1 (test:examples) (first run)
Preprocessing library for splitmix-0.1.3.1...
Building library for splitmix-0.1.3.1...
Configuring test suite 'splitmix-tests' for splitmix-0.1.3.1...
Configuring test suite 'splitmix-th-test' for splitmix-0.1.3.1...
Configuring test suite 'splitmix-dieharder' for splitmix-0.1.3.1...
Configuring test suite 'montecarlo-pi-32' for splitmix-0.1.3.1...
Preprocessing test suite 'montecarlo-pi-32' for splitmix-0.1.3.1...
Building test suite 'montecarlo-pi-32' for splitmix-0.1.3.1...
Preprocessing test suite 'splitmix-th-test' for splitmix-0.1.3.1...
Building test suite 'splitmix-th-test' for splitmix-0.1.3.1...
Preprocessing test suite 'splitmix-dieharder' for splitmix-0.1.3.1...
Building test suite 'splitmix-dieharder' for splitmix-0.1.3.1...
Preprocessing test suite 'splitmix-tests' for splitmix-0.1.3.1...
Building test suite 'splitmix-tests' for splitmix-0.1.3.1...
[1 of 1] Compiling Main             ( tests/SplitMixPi32.hs, dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/montecarlo-pi-32/build/montecarlo-pi-32/montecarlo-pi-32-tmp/Main.o )
[1 of 1] Compiling Main             ( tests/splitmix-th-test.hs, dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/splitmix-th-test/build/splitmix-th-test/splitmix-th-test-tmp/Main.o )
[1 of 1] Compiling Main             ( tests/Dieharder.hs, dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/splitmix-dieharder/build/splitmix-dieharder/splitmix-dieharder-tmp/Main.o )
[1 of 3] Compiling MiniQC           ( tests/MiniQC.hs, dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/splitmix-tests/build/splitmix-tests/splitmix-tests-tmp/MiniQC.o )
[2 of 3] Compiling Uniformity       ( tests/Uniformity.hs, dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/splitmix-tests/build/splitmix-tests/splitmix-tests-tmp/Uniformity.o )

tests/Dieharder.hs:252:17: warning: [GHC-63394] [-Wx-partial]
    In the use of ‘head’
    (imported from Prelude, but defined in GHC.List):
    "This is a partial function, it throws an error on empty lists. Use pattern matching or Data.List.uncons instead. Consider refactoring to use Data.List.NonEmpty."
    |
252 |     | null x || head x /= '-'     = Right (xs, fmap ($ x) p)
    |                 ^^^^
[2 of 2] Linking dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/montecarlo-pi-32/build/montecarlo-pi-32/montecarlo-pi-32
[3 of 3] Compiling Main             ( tests/Tests.hs, dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/splitmix-tests/build/splitmix-tests/splitmix-tests-tmp/Main.o )
[2 of 2] Linking dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/splitmix-th-test/build/splitmix-th-test/splitmix-th-test
ld.lld: warning: OSThreads.c(OSThreads.o:(createAttachedOSThread) in archive /usr/local/lib/ghc-9.8.3/lib/../lib/x86_64-openbsd-ghc-9.8.3/rts-1.0.2/libHSrts-1.0.2.a): warning: strcpy() is almost always misused, please use strlcpy()
ld.lld: warning: EventLogWriter.c(EventLogWriter.o:(initEventLogFileWriter) in archive /usr/local/lib/ghc-9.8.3/lib/../lib/x86_64-openbsd-ghc-9.8.3/rts-1.0.2/libHSrts-1.0.2.a): warning: sprintf() is often misused, please use snprintf()
ld.lld: warning: RtsFlags.c(RtsFlags.thr_o:(setupRtsFlags) in archive /usr/local/lib/ghc-9.8.3/lib/../lib/x86_64-openbsd-ghc-9.8.3/rts-1.0.2/libHSrts-1.0.2_thr.a): warning: strcpy() is almost always misused, please use strlcpy()
ld.lld: warning: ProfHeap.c(ProfHeap.thr_o:(initHeapProfiling) in archive /usr/local/lib/ghc-9.8.3/lib/../lib/x86_64-openbsd-ghc-9.8.3/rts-1.0.2/libHSrts-1.0.2_thr.a): warning: sprintf() is often misused, please use snprintf()
Configuring test suite 'montecarlo-pi' for splitmix-0.1.3.1...
Configuring test suite 'initialization' for splitmix-0.1.3.1...
[4 of 4] Linking dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/splitmix-tests/build/splitmix-tests/splitmix-tests
[2 of 2] Linking dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/splitmix-dieharder/build/splitmix-dieharder/splitmix-dieharder
ld.lld: warning: Linker.c(Linker.o:(mkOc) in archive /usr/local/lib/ghc-9.8.3/lib/../lib/x86_64-openbsd-ghc-9.8.3/rts-1.0.2/libHSrts-1.0.2.a): warning: strcpy() is almost always misused, please use strlcpy()
ld.lld: warning: EventLogWriter.c(EventLogWriter.o:(initEventLogFileWriter) in archive /usr/local/lib/ghc-9.8.3/lib/../lib/x86_64-openbsd-ghc-9.8.3/rts-1.0.2/libHSrts-1.0.2.a): warning: sprintf() is often misused, please use snprintf()
ld.lld: warning: OSThreads.c(OSThreads.thr_o:(createAttachedOSThread) in archive /usr/local/lib/ghc-9.8.3/lib/../lib/x86_64-openbsd-ghc-9.8.3/rts-1.0.2/libHSrts-1.0.2_thr.a): warning: strcpy() is almost always misused, please use strlcpy()
ld.lld: warning: EventLogWriter.c(EventLogWriter.thr_o:(initEventLogFileWriter) in archive /usr/local/lib/ghc-9.8.3/lib/../lib/x86_64-openbsd-ghc-9.8.3/rts-1.0.2/libHSrts-1.0.2_thr.a): warning: sprintf() is often misused, please use snprintf()
Configuring test suite 'examples' for splitmix-0.1.3.1...
Preprocessing test suite 'montecarlo-pi' for splitmix-0.1.3.1...
Building test suite 'montecarlo-pi' for splitmix-0.1.3.1...
Preprocessing test suite 'initialization' for splitmix-0.1.3.1...
Building test suite 'initialization' for splitmix-0.1.3.1...
[1 of 1] Compiling Main             ( tests/SplitMixPi.hs, dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/montecarlo-pi/build/montecarlo-pi/montecarlo-pi-tmp/Main.o )
[1 of 1] Compiling Main             ( tests/Initialization.hs, dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/initialization/build/initialization/initialization-tmp/Main.o )
[2 of 2] Linking dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/montecarlo-pi/build/montecarlo-pi/montecarlo-pi
[2 of 2] Linking dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/initialization/build/initialization/initialization
ld.lld: warning: RtsUtils.c(RtsUtils.o:(showStgWord64) in archive /usr/local/lib/ghc-9.8.3/lib/../lib/x86_64-openbsd-ghc-9.8.3/rts-1.0.2/libHSrts-1.0.2.a): warning: sprintf() is often misused, please use snprintf()
ld.lld: warning: OSThreads.c(OSThreads.o:(createAttachedOSThread) in archive /usr/local/lib/ghc-9.8.3/lib/../lib/x86_64-openbsd-ghc-9.8.3/rts-1.0.2/libHSrts-1.0.2.a): warning: strcpy() is almost always misused, please use strlcpy()
ld.lld: warning: OSThreads.c(OSThreads.thr_o:(createAttachedOSThread) in archive /usr/local/lib/ghc-9.8.3/lib/../lib/x86_64-openbsd-ghc-9.8.3/rts-1.0.2/libHSrts-1.0.2_thr.a): warning: strcpy() is almost always misused, please use strlcpy()
ld.lld: warning: EventLogWriter.c(EventLogWriter.thr_o:(initEventLogFileWriter) in archive /usr/local/lib/ghc-9.8.3/lib/../lib/x86_64-openbsd-ghc-9.8.3/rts-1.0.2/libHSrts-1.0.2_thr.a): warning: sprintf() is often misused, please use snprintf()
Preprocessing test suite 'examples' for splitmix-0.1.3.1...
Building test suite 'examples' for splitmix-0.1.3.1...
[1 of 1] Compiling Main             ( tests/Examples.hs, dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/examples/build/examples/examples-tmp/Main.o )
[2 of 2] Linking dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/examples/build/examples/examples
ld.lld: warning: OSThreads.c(OSThreads.o:(createAttachedOSThread) in archive /usr/local/lib/ghc-9.8.3/lib/../lib/x86_64-openbsd-ghc-9.8.3/rts-1.0.2/libHSrts-1.0.2.a): warning: strcpy() is almost always misused, please use strlcpy()
ld.lld: warning: EventLogWriter.c(EventLogWriter.o:(initEventLogFileWriter) in archive /usr/local/lib/ghc-9.8.3/lib/../lib/x86_64-openbsd-ghc-9.8.3/rts-1.0.2/libHSrts-1.0.2.a): warning: sprintf() is often misused, please use snprintf()

vvx@kitt:~/prgs/splitmix$ cabal test
[...]
Test suite splitmix-tests: PASS
Test suite logged to:
/home/vvx/prgs/splitmix/./dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/splitmix-tests/test/splitmix-0.1.3.1-splitmix-tests.log
1 of 1 test suites (1 of 1 test cases) passed.
3.14143336
1.592935897929415e-4
Test suite montecarlo-pi: PASS
Test suite logged to:
/home/vvx/prgs/splitmix/./dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/montecarlo-pi/test/splitmix-0.1.3.1-montecarlo-pi.log
1 of 1 test suites (1 of 1 test cases) passed.
3.1411405
4.5228004e-4
Test suite montecarlo-pi-32: PASS
Test suite logged to:
/home/vvx/prgs/splitmix/./dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/montecarlo-pi-32/test/splitmix-0.1.3.1-montecarlo-pi-32.log
1 of 1 test suites (1 of 1 test cases) passed.
Running 1 test suites...
Test suite splitmix-th-test: RUNNING...
0.8022683075172943
Test suite splitmix-th-test: PASS
Test suite logged to:
/home/vvx/prgs/splitmix/./dist-newstyle/build/x86_64-openbsd/ghc-9.8.3/splitmix-0.1.3.1/t/splitmix-th-test/test/splitmix-0.1.3.1-splitmix-th-test.log
1 of 1 test suites (1 of 1 test cases) passed.
```